### PR TITLE
Support eight.__name__ and raise correct AttributeError

### DIFF
--- a/Changes.rst
+++ b/Changes.rst
@@ -1,10 +1,14 @@
-Version 0.3.2 (2015-05-08)
+Version 0.3.4 (???)
 --------------------------
-- Import order fix for 0.3.1
+- Fix redirecting module loader to allow eight.__name__ and return correct error for invalid attribute
 
 Version 0.3.3 (2015-11-06)
 --------------------------
 - Bump python-future dependency
+
+Version 0.3.2 (2015-05-08)
+--------------------------
+- Import order fix for 0.3.1
 
 Version 0.3.1 (2015-05-08)
 --------------------------

--- a/eight/__init__.py
+++ b/eight/__init__.py
@@ -70,10 +70,15 @@ class Loader(object):
             return self.__file__
         elif attr == '__loader__':
             return None
+        elif attr == '__name__':
+            return self._name
         elif attr in self._manifest:
             return self._map[attr]
         else:
-            return self._sys.modules[self._name + '.' + attr]
+            try:
+                return self._sys.modules[self._name + '.' + attr]
+            except KeyError:
+                raise AttributeError("'module' object has no attribute '" + attr + "'")
 
     def __dir__(self):
         return list(self._map)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ install_requires = [line.rstrip() for line in open(os.path.join(os.path.dirname(
 
 setup(
     name='eight',
-    version='0.3.3',
+    version='0.3.4.dev0',
     url='https://github.com/kislyuk/eight',
     license='Apache Software License',
     author='Andrey Kislyuk',

--- a/test/test.py
+++ b/test/test.py
@@ -51,5 +51,13 @@ class TestEight(unittest.TestCase):
     def test_decode_command_line_args(self):
         pass
 
+    def test_name(self):
+        self.assertEqual(eight.__name__, 'eight')
+
+    def test_nonexistent_attribute(self):
+        with self.assertRaises(AttributeError):
+            eight.foobar
+        self.assertFalse(hasattr(eight, 'foobar'))
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Eight interacts badly with libraries that inspect the `__name__` attribute of a module. These include things like test libraries that are trying to do dynamic patching like freezegun. Specifically, eight behaves badly when freezegun inspects it at https://github.com/spulec/freezegun/blob/0.3.7/freezegun/api.py#L381 because the loader's `__getattribute__()` tries to look up `eight.__name__` in `sys.modules` instead of returning the name it already stored.

This PR adds support for `__name__`, as well as raising the correct AttributeError expected when a non-existent attribute is searched for instead of bubbling up the KeyError. By raising AttributeError, this allows `hasattr(eight, 'foo')` to work properly.
